### PR TITLE
Changed indentation for (unless ...)

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -16,7 +16,7 @@
     /^let/, /^import/, "new", /^deftype/, /^let/, "fn", "recur", /^set.*!$/,
     ".", "var", "quote", "catch", "throw", "monitor-enter",
 
-    'ns', 'in-ns', /^([^\/]+\/)?def/,/^if/,/^when/,/->/, "while", "for",
+    'ns', 'in-ns', /^([^\/]+\/)?def/,/^if/,/^when/,/^unless/,/->/, "while", "for",
     /(^|\/)with/, "testing", "while", "cond", "condp", "apply",
     "binding", "locking", "proxy", "reify", /^extend/,
 


### PR DESCRIPTION
Hello!

First of all, I'd like to thank you for this fantastic library! I'm using it in some of my code, and I'm using other libraries that use it. Nice work!

I think it's great that your library can auto-indent code, and makes an effort to do so according to Lisp idioms (for instance, `let`, `when`, etc). Combined with the Atom package `lisp-paredit`, Atom is one of the few editors I've come across other than Emacs that can actually properly indent Lisp code, so thanks to your hard work.

I've noticed a few forms are indented a bit differently with respect to [these standards for Common Lisp](http://dept-info.labri.u-bordeaux.fr/~strandh/Teaching/PFS/Common/Strandh-Tutorial/indentation.html). This patch submits a fix for `unless` (which is indented just like `when`).

The other forms I've noticed (but rarely use myself, so I personally care less about them :-) ) are `do` and `if`. Perhaps the indentation rules are different across different Lisps, but for Common Lisp I believe the norm is:

```
(if (condition here)
    (then is same level of condition)
    (and so is the else))
```

`paredit.js` seems to indent as this though:
```
(if (come condition)
  (then is less indented here)
  (so is else))
```

Also, `do` has different indentation rules, too. I'm curious what you think?

Again, thanks for your hard work on this very-useful library!

Cheers,
Steve

P.S. I'm using `paredit.js` in two packages of my own: `swank-client-js` and an Atom package `atom-slime`, which together with `lisp-paredit` will hopefully make Atom a more full-featured IDE for Common Lisp.

