### PR TITLE
Move cursor left upon delete sometimes

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -382,6 +382,7 @@
           left = isInList && leftSiblings(parent, idx),
           right = isInList && rightSiblings(parent, idx),
           noDelete = {changes: [], newIndex: idx},
+          moveLeft = {changes: [], newIndex: idx-1},
           simpleDelete = {
             changes: [['remove', backward ? idx-count : idx, count]],
             newIndex: backward ? idx-count : idx
@@ -394,6 +395,7 @@
         var n = last(left);
         if (n.end !== idx || isSaveToPartialDelete(n)) return simpleDelete;
         if (isEmpty(n) || n.type === "char") return deleteSexp(n);
+        if (count == 1) return moveLeft;
         return noDelete;
       }
 

--- a/tests/editor-test.js
+++ b/tests/editor-test.js
@@ -297,7 +297,11 @@ describe('paredit editor', function() {
     edit("delete",{backward: true})
       .transforms("deletes empty lists backward but only at beginning", "( |)->(|)")
       .withChanges([['remove', 1, 1]]);
-;
+
+    edit("delete",{backward: true})
+      .transforms("moves cursor backwards", "(())|->(()|)")
+      .withChanges([]);
+
     edit("delete",{backward: false})
       .transforms("deletes empty lists forward","(|)->|")
       .withChanges([['remove', 0, 2]]);


### PR DESCRIPTION
Hi again Robert,

Thanks again for all your hard work on a great package!

One behavior I really like from Emacs' paredit is moving the cursor left under a backwards delete sometimes. For example, if buffer looks like `(())|` and backspace is pressed, the result is `(()|)` instead of remaining unchanged. I personally find this feature really handy for moving around parts of my code quickly and avoiding the arrow keys, and also for deleting lines of code one character at a time.

I've created a pull request for you that implements this behavior. What do you think? If you don't want to enable this behavior by default, a thought I had would be to put a flag in `args`.

Thanks so much!

All the best,
Steve
