### PR TITLE
Create Error if a String Ends Without a Closing Quote

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -136,11 +136,17 @@
       else if (c === "\\") escaped = true;
       return true;
     }, function(read, rest, prevPos, newPos) {
-      string = string + read + rest[0];
-      newPos = forward(newPos, rest[0]); rest = rest.slice(1);
-      var result = callTransform(xform, "string", string, startPos, newPos,
-        {open: '"', close: '"'});
-      context = context.concat([result]);
+      if (rest[0] == '"') {
+        string = string + read + rest[0];
+        newPos = forward(newPos, rest[0]); rest = rest.slice(1);
+        var result = callTransform(xform, "string", string, startPos, newPos,
+          {open: '"', close: '"'});
+        context = context.concat([result]);
+      } else {
+        string = string + read;
+        var err = readError("Expected '\"' but reached end of input", startPos, newPos, null);
+        var result = callTransform(xform, "error", err, prevPos, newPos);
+      }
       return {pos:newPos,input:rest,context:context};
     });
   }


### PR DESCRIPTION
Currently, if a string doesn't have a closing quote, doesn't create any errors.  sjlevine/atom-slime#81 uses paredit errors to detect when a line is incomplete, so this would allow it to behave correctly when a user is typing just a string (its a corner case, since most of the time there will be a missing closing paren as the string goes until eof).  The fix checks whether the next character is an double quote (instead of assuming it is and discarding it) and, if it isn't, an error is created instead of a string.

For example calling `parse` with just the string `"`, paredit produces (when output in chromimum dev tools)
![image](https://user-images.githubusercontent.com/17600257/55369415-18502080-54bc-11e9-9e49-d8654e833adb.png)
This PR modifies paredit to provide an error instead:
![image](https://user-images.githubusercontent.com/17600257/55369736-687bb280-54bd-11e9-9018-5c27a0e74525.png)

I couldn't get the tests running on my machine, so there isn't any change to the test suite.  If you want a test in the suite, the following should work:
```
it("unmatched string quote", function() {
  var actual = readSeq('"a'),
      expected = [
        "a",
        {error: "Expected '\"' but reached end of input at line 1 column 2"}]
  console.log(diff(actual,expected));
  expect(actual).to.containSubset(expected);
});
```