### PR TITLE
Fix readNumber for decimals and negatives

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -59,6 +59,10 @@
     if (ch === '"')              return readString(input, context, pos, xform);
     if (ch === '\\')             return readChar(input, context, pos, xform);
     if (/[0-9]/.test(ch))        return readNumber(input, context, pos, xform);
+    if (ch === '-' && (/[0-9]/.test(input[1]) || (input[1] == '.' && /[0-9]/.test(input[2]))))
+                                 return readNumber(input, context, pos, xform);
+    if (ch === '.' && (/[0-9]/.test(input[1])))
+                                 return readNumber(input, context, pos, xform);
     if (symRe.test(ch))          return readSymbol(input, context, pos, xform);
 
     // 5. list end?
@@ -174,8 +178,20 @@
   }
 
   function readNumber(input, context, pos, xform) {
+    first = true;
+    seenSeperator = false;
     return takeWhile(input, pos,
-      function(c) { return /[0-9]/.test(c); },
+      function(c) {
+        if (first) {
+          first = false;
+          if (c === '-') return true;
+        }
+        if(seenSeperator && c === '.') {
+          seenSeperator = false;
+          return true
+        }
+        return /[0-9.]/.test(c);
+      },
       function(read, rest, prevPos, newPos) {
         var result = callTransform(xform, "number", Number(read), prevPos, newPos);
         context = context.concat([result])

--- a/tests/reader-test.js
+++ b/tests/reader-test.js
@@ -87,6 +87,11 @@ describe('reading sexps', function() {
   describe("numbers", function() {
     it("reads number value", function() {
       expect(readSexp('123')).eq(123);
+      expect(readSexp('123.55')).eq(123.55);
+      expect(readSexp('.123')).eq(.123);
+      expect(readSexp('-123')).eq(-123);
+      expect(readSexp('-123.55')).eq(-123.55);
+      expect(readSexp('-.123')).eq(-.123);
     });
   });
 


### PR DESCRIPTION
readNumber previously didn't support numbers with decimals in them or negatives.  For example `"(0.2)"` was being read as `[0, .2]`.  I expanded the test cases, but still couldn't get the tests running on my machine.