### PR TITLE
Await `Promise.all` for parallel module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ await load();
 
 async function load() {
   var lm = lively.modules,
+      p = lm.getPackage("paredit.js"),
       files = ["./index.js",
                './lib/util.js',
                "./lib/reader.js",
@@ -27,8 +28,8 @@ async function load() {
                // "./tests/reader-test.js",
                // "./tests/navigator-test.js",
                // "./tests/editor-test.js"
-              ],
-      p = lm.getPackage("paredit.js");
-  for (let f of files) await lm.module(lively.lang.string.joinPath(p.url, f)).reload();
+              ].map(f => lm.module(lively.lang.string.joinPath(p.url, f)).reload()),
+     ;
+  await Promise.all(files);
 }
 ```


### PR DESCRIPTION
Noticed that this process would be blocked in the `for` loop as each module being loaded was `await`ed in sequence,
thought I'd suggest getting the promises back from `reload()` via `map` so that the modules could be loaded in parallel 
and the function could finish when `await Promise.all` completed.

Not sure if this breaks the function or not; not a Paredit user, just arrived here as I traversed down a rabbit hole from Gitlab's Web IDE documentation page