### PR TITLE
Fix 'Uncaught ReferenceError'

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -178,8 +178,8 @@
   }
 
   function readNumber(input, context, pos, xform) {
-    first = true;
-    seenSeperator = false;
+    var first = true,
+        seenSeperator = false;
     return takeWhile(input, pos,
       function(c) {
         if (first) {


### PR DESCRIPTION
I'm trying to convert this library as a ECMAScript module and use it in [Deno](https://deno.land).
But it fails with the following error.

```
error: Uncaught ReferenceError: first is not defined
      first = true;
```

This PR fixes this error.

## How to reproduce

Convert to ESM with [esbuild](https://esbuild.github.io) as `esm.js`
```
esbuild index.js --bundle --format=esm --outfile=esm.js`
```

Create test.ts
```ts
import paredit from "./esm.js";
console.log(paredit.parse("(+ 1 2)"));
```

Run test script
```
deno run test.ts
```