### PR TITLE
Fix type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,16 +98,16 @@ export namespace editor {
     type DeleteArgs = { count?: number, backward?: boolean, endIdx?: number, freeEdits?: boolean }
     export function rewrite(ast: AST, nodeToReplace: InnerNode, newNodes: InnerNode[]): AST
     export function openList(ast: AST, src: string, idx: number, args?: OpenListArgs): EditorChanges
-    export function spliceSexp(ast: AST, src: string, idx: number): EditorChanges
-    export function spliceSexpKill(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges
-    export function killSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function wrapAround(ast: AST, src: string, idx: number, wrapWithStart: string, wrapWithEnd: string, args?: WrapArgs): EditorChanges
-    export function closeAndNewLine(ast: AST, src: string, idx: number, close?: string): EditorChanges
-    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges
-    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function transpose(ast: AST, src: string, idx: number, args?: {}): EditorChanges // args?
-    function deleteX(ast: AST, src: string, idx: number, args?: DeleteArgs): EditorChanges
+    export function spliceSexp(ast: AST, src: string, idx: number): EditorChanges | null
+    export function spliceSexpKill(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
+    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges | null | undefined // The `undefined` path may not be intentional
+    export function killSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
+    export function wrapAround(ast: AST, src: string, idx: number, wrapWithStart: string, wrapWithEnd: string, args?: WrapArgs): EditorChanges | null
+    export function closeAndNewLine(ast: AST, src: string, idx: number, close?: string): EditorChanges | null
+    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges | null | undefined // The `undefined` path may not be intentional
+    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null | undefined  // The `undefined` path may not be intentional
+    export function transpose(ast: AST, src: string, idx: number, args?: {}): EditorChanges | null // args?
+    function deleteX(ast: AST, src: string, idx: number, args?: DeleteArgs): EditorChanges | null
     export { deleteX as delete } // hackish way to export 'delete', which is a reserved word
     export function indentRange(ast: AST, src: string, start: number, end: number): Indent
 }


### PR DESCRIPTION
Hi, thanks very much for this excellent library cc @sgarciac.

I noticed these small errors in the type declaration files.

It's possible that all the falsey code paths should return `null` rather than undefined but since that would be a breaking change I'll open a separate PR for it, in case you want to do that.

(I'm using this library while contributing to [this VSCode Emacs emulation extension](https://github.com/whitphx/vscode-emacs-mcx)).