### PR TITLE
null vs undefined value consistency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,16 +98,16 @@ export namespace editor {
     type DeleteArgs = { count?: number, backward?: boolean, endIdx?: number, freeEdits?: boolean }
     export function rewrite(ast: AST, nodeToReplace: InnerNode, newNodes: InnerNode[]): AST
     export function openList(ast: AST, src: string, idx: number, args?: OpenListArgs): EditorChanges
-    export function spliceSexp(ast: AST, src: string, idx: number): EditorChanges
-    export function spliceSexpKill(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges
-    export function killSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function wrapAround(ast: AST, src: string, idx: number, wrapWithStart: string, wrapWithEnd: string, args?: WrapArgs): EditorChanges
-    export function closeAndNewLine(ast: AST, src: string, idx: number, close?: string): EditorChanges
-    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges
-    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges
-    export function transpose(ast: AST, src: string, idx: number, args?: {}): EditorChanges // args?
-    function deleteX(ast: AST, src: string, idx: number, args?: DeleteArgs): EditorChanges
+    export function spliceSexp(ast: AST, src: string, idx: number): EditorChanges | null
+    export function spliceSexpKill(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
+    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges | null | undefined // The `undefined` path may not be intentional
+    export function killSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
+    export function wrapAround(ast: AST, src: string, idx: number, wrapWithStart: string, wrapWithEnd: string, args?: WrapArgs): EditorChanges | null
+    export function closeAndNewLine(ast: AST, src: string, idx: number, close?: string): EditorChanges | null
+    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges | null | undefined // The `undefined` path may not be intentional
+    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null | undefined  // The `undefined` path may not be intentional
+    export function transpose(ast: AST, src: string, idx: number, args?: {}): EditorChanges | null // args?
+    function deleteX(ast: AST, src: string, idx: number, args?: DeleteArgs): EditorChanges | null
     export { deleteX as delete } // hackish way to export 'delete', which is a reserved word
     export function indentRange(ast: AST, src: string, start: number, end: number): Indent
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,12 +100,12 @@ export namespace editor {
     export function openList(ast: AST, src: string, idx: number, args?: OpenListArgs): EditorChanges
     export function spliceSexp(ast: AST, src: string, idx: number): EditorChanges | null
     export function spliceSexpKill(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
-    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges | null | undefined // The `undefined` path may not be intentional
+    export function splitSexp(ast: AST, src: string, idx: number): EditorChanges | null
     export function killSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
     export function wrapAround(ast: AST, src: string, idx: number, wrapWithStart: string, wrapWithEnd: string, args?: WrapArgs): EditorChanges | null
     export function closeAndNewLine(ast: AST, src: string, idx: number, close?: string): EditorChanges | null
-    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges | null | undefined // The `undefined` path may not be intentional
-    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null | undefined  // The `undefined` path may not be intentional
+    export function barfSexp(ast: AST, src: string, idx: number, args?: SexpBarfArgs): EditorChanges | null
+    export function slurpSexp(ast: AST, src: string, idx: number, args?: CountAndBackwardArgs): EditorChanges | null
     export function transpose(ast: AST, src: string, idx: number, args?: {}): EditorChanges | null // args?
     function deleteX(ast: AST, src: string, idx: number, args?: DeleteArgs): EditorChanges | null
     export { deleteX as delete } // hackish way to export 'delete', which is a reserved word

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -176,7 +176,7 @@
       var sexps = w.containingSexpsAt(ast,idx);
       if (!sexps.length) return null;
       var sexp = sexps.pop();
-      if (sexp.type === "toplevel") return;
+      if (sexp.type === "toplevel") return null;
       if (!w.hasChildren(sexp) && sexp.type !== "string")
         return null;
       // we are dealing with a list or string split
@@ -276,7 +276,7 @@
           ['remove', parent.start, parent.open.length]];
       } else {
         var right = rightSiblings(parent, idx);
-        if (!right.length) return;
+        if (!right.length) return null;
         var changes = [
           ['remove', parent.end-parent.close.length, parent.close.length],
           ['insert', right[right.length-2] ? right[right.length-2].end : (inner ? inner.end : idx), parent.close]];
@@ -293,13 +293,13 @@
       var parentParent = sexps.pop();
       if (backward) {
         var left = leftSiblings(parentParent, idx);
-        if (!left.length) return;
+        if (!left.length) return null;
         var changes = [
           ['remove', parent.start, parent.open.length],
           ['insert', left.slice(-count)[0].start, parent.open]];
       } else {
         var right = rightSiblings(parentParent, idx);
-        if (!right.length) return;
+        if (!right.length) return null;
         var changes = [
           ['insert', last(right.slice(0,count)).end, parent.close],
           ['remove', parent.end-parent.close.length, parent.close.length]];


### PR DESCRIPTION
See https://github.com/rksm/paredit.js/pull/27 cc @sgarciac 

#27 merely changes the type declarations to match reality, but this PR additionally changes some return values, and hence would be a breaking change. I'm not sure if these changes are how the code was intended to be but it seemed possible, so opening the PR just in case it's useful.